### PR TITLE
Fix bug in renaming

### DIFF
--- a/DataUtil.hs
+++ b/DataUtil.hs
@@ -64,8 +64,9 @@ renaming e1 e2 = f $ partition isNothing $ renaming' (e1, e2) where
   f (_, ps) = g gs1 gs2
     where
       gs1 = groupBy (\(a, b) (c, d) -> a == c) $ sortBy h $ nub $ catMaybes ps
-      gs2 = groupBy (\(a, b) (c, d) -> b == d) $ sortBy h $ nub $ catMaybes ps
+      gs2 = groupBy (\(a, b) (c, d) -> b == d) $ sortBy j $ nub $ catMaybes ps
       h (a, b) (c, d) = compare a c
+      j (a, b) (c, d) = compare b d
   g xs ys = if all ((== 1) . length) xs && all ((== 1) . length) ys
     then Just (concat xs) else Nothing
 


### PR DESCRIPTION
It looks like a bug... 
If I understand correctly, you want to check that renaming is a bijection, i.e. there are no two entries with different first component and the same second component, and vice versa.
If so, look at `[(a, d), (c, b), (c, d)]`. You're returning `Just` it, though it's not a bijection.


`renaming` is pretty messy in general, can I rewrite it?